### PR TITLE
Fixes issues 33 & 34

### DIFF
--- a/oxipay.php
+++ b/oxipay.php
@@ -256,7 +256,6 @@ function woocommerce_oxipay_init() {
         function process_payment( $order_id ) {
             global $woocommerce;
             $order = new WC_Order( $order_id );
-			$order->update_status('pending');
 			$gatewayUrl = $this->getGatewayUrl();
 
 			$isValid = true;
@@ -267,8 +266,6 @@ function woocommerce_oxipay_init() {
 
 			if(!$isValid) return;
 
-			$order->update_status('processing', __('Awaiting Oxipay payment processing to complete.', 'woocommerce'));
-
             $transaction_details = array (
                 'x_reference'     				=> $order_id,
                 'x_account_id'    				=> $this->settings['oxipay_merchant_id'],
@@ -276,7 +273,7 @@ function woocommerce_oxipay_init() {
                 'x_currency' 	    			=> $this->getCurrencyCode(),
                 'x_url_callback'  				=> plugins_url("callback.php", __FILE__),
                 'x_url_complete'  				=> $this->get_return_url( $order ),
-                'x_url_cancel'           		=> $woocommerce->cart->get_cart_url(),
+                'x_url_cancel'           		=> esc_url_raw( $order->get_cancel_order_url_raw() ),
                 'x_test'          				=> $this->settings['test_mode'],
                 'x_shop_country'          		=> $this->getCountryCode(),
                 'x_shop_name'          			=> $this->settings['shop_name'],
@@ -305,7 +302,6 @@ function woocommerce_oxipay_init() {
           	$signature = oxipay_sign($transaction_details, $this->settings['oxipay_api_key']);
 			$transaction_details['x_signature'] = $signature;
 
-            $order->update_status('on-hold', __('Awaiting '.Config::DISPLAY_NAME.' payment', 'woothemes'));
             $qs = http_build_query($transaction_details);
 
             return array(


### PR DESCRIPTION
- line 259: No need to set to pending status, because that's how orders start their life, see plugins\woocommerce\includes\wc-core-functions.php, line 80.
- line 269: The processing status is to indicate payment was successful and you can now process (pack, ship etc.) the order. That's not the case yet, so don't use this status right now.
- line 280: Simply returning to cart will not cancel the order. The 'cancel_order_url' will, because it will be parsed by plugins\woocommerce\includes\class-wc-form-handler.php, cancel_order (line 649). This method also requires the status of the order to be pending or failed for it to be able to cancel (set status to cancelled), so we need to remove the on-hold status as well.
- line 308: The on-hold status is for payment methods that require additional manual steps that we can't wait for. It blocks us from actually cancelling the order.

By removing all these update-status calls, the behavior has becomes the same as the PayPal payment gateway.