### PR TITLE
Resolves issues when canceling orders and duplicate emails

### DIFF
--- a/oxipay.php
+++ b/oxipay.php
@@ -256,7 +256,6 @@ function woocommerce_oxipay_init() {
         function process_payment( $order_id ) {
             global $woocommerce;
             $order = new WC_Order( $order_id );
-			$order->update_status('pending');
 			$gatewayUrl = $this->getGatewayUrl();
 
 			$isValid = true;
@@ -267,8 +266,6 @@ function woocommerce_oxipay_init() {
 
 			if(!$isValid) return;
 
-			$order->update_status('processing', __('Awaiting Oxipay payment processing to complete.', 'woocommerce'));
-
             $transaction_details = array (
                 'x_reference'     				=> $order_id,
                 'x_account_id'    				=> $this->settings['oxipay_merchant_id'],
@@ -276,7 +273,7 @@ function woocommerce_oxipay_init() {
                 'x_currency' 	    			=> $this->getCurrencyCode(),
                 'x_url_callback'  				=> plugins_url("callback.php", __FILE__),
                 'x_url_complete'  				=> $this->get_return_url( $order ),
-                'x_url_cancel'           		=> $woocommerce->cart->get_cart_url(),
+                'x_url_cancel'           		=> esc_url_raw( $order->get_cancel_order_url_raw() ),
                 'x_test'          				=> $this->settings['test_mode'],
                 'x_shop_country'          		=> $this->getCountryCode(),
                 'x_shop_name'          			=> $this->settings['shop_name'],
@@ -305,7 +302,6 @@ function woocommerce_oxipay_init() {
           	$signature = oxipay_sign($transaction_details, $this->settings['oxipay_api_key']);
 			$transaction_details['x_signature'] = $signature;
 
-            $order->update_status('on-hold', __('Awaiting '.Config::DISPLAY_NAME.' payment', 'woothemes'));
             $qs = http_build_query($transaction_details);
 
             return array(

--- a/oxipay.php
+++ b/oxipay.php
@@ -411,6 +411,9 @@ function woocommerce_oxipay_init() {
 		 */
 		function payment_finalisation($order_id)
 		{
+			$payment_method = get_post_meta( $order_id, '_payment_method', true );
+			if ($payment_method != "oxipay") return $order_id;
+
 			$order = wc_get_order($order_id);
 			$cart = WC()->session->get('cart', null);
 			$full_url = "http://$_SERVER[HTTP_HOST]$_SERVER[REQUEST_URI]";
@@ -441,8 +444,6 @@ function woocommerce_oxipay_init() {
 						$order->update_status('on-hold', 'Error may have occurred with ' . Config::DISPLAY_NAME . '. Reference #'. $params['x_gateway_reference']);
 						break;
 				}
-
-				return $order_id;
 			}
 			else
 			{
@@ -450,6 +451,8 @@ function woocommerce_oxipay_init() {
 				$order->add_order_note(__('Payment declined using ' . Config::DISPLAY_NAME . '. Your Order ID is ' . $order->id, 'woocommerce'));
 				$order->update_status('failed');
 			}
+
+			return $order_id;
 		}
 
 		/**


### PR DESCRIPTION
Resolves the following issues:
1 - Cancelled orders no longer show as "On Hold" in orders screen.
2 - Email receipts no longer generated for simply clicking on "Proceed to Oxipay"
3 - Cancelling an order no longer clears the cart