### PR TITLE
A

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,21 @@
+version: '2'
+
+services:
+
+  wordpress:
+    image: wordpress
+    ports:
+      - 8080:80
+    environment:
+      WORDPRESS_DB_PASSWORD: t9e3ioz0
+    depends_on:
+      - mysql
+    links:
+      - mysql
+    volumes:
+      - "../:/var/www/html/wp-content/plugins/oxipay-woocommerce"
+
+  mysql:
+    image: mariadb
+    environment:
+      MYSQL_ROOT_PASSWORD: t9e3ioz0

--- a/oxipay.php
+++ b/oxipay.php
@@ -576,7 +576,7 @@ function woocommerce_oxipay_init() {
 			$valid_addresses = (count(array_unique($set_addresses)) === 1 && end($set_addresses) === $countryCode);
 			
 			if (!$valid_addresses) {
-			$errorMessage = "&nbsp;Orders from outside " . $this->getCountryName() . " are not supported by " . Config::DISPLAY_NAME .". Please select a different payment option.";
+				$errorMessage = "&nbsp;Orders from outside " . $this->getCountryName() . " are not supported by " . Config::DISPLAY_NAME .". Please select a different payment option.";
 				$order->cancel_order($errorMessage);
 				$this->logValidationError($errorMessage);
 				return false;


### PR DESCRIPTION
* Enabled use of WooCommerce logger
* Added a method to  determine the country of the merchant based on comments provided in task description
   

> 
>  At the plugin level there are two ways to determine the country
> of a merchant:
> 
> a.       By the ccTLD of the configured payment gateway URL e.g. .com.au
> or .co.nz (‘payment gateway URL’ is a plugin configuration in
> WordPress/WooCommerce admin)
> b.      By the configured country code (plugin configuration in
> WordPress/WooCommerce admin)
> 

* Added a check to ensure that the current WooCommerce currency matches that of Oxipay Region