### PR TITLE
OIR-4: only create releases when we specifically tag a build as 'rele…

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,7 +21,8 @@ deploy:
   prerelease: false
   on:
     branch: master
-    appveyor_repo_tag: false
+    appveyor_repo_tag: true
+    appveyor_repo_tag_name: 'release'
 notifications:
   - provider: Email
     to:


### PR DESCRIPTION
Modifies the appveyor build to only create releases on github if you tag with release-*