### PR TITLE
Just check that the application/json is contained in the content type…

### DIFF
--- a/WC_Oxipay_Gateway.php
+++ b/WC_Oxipay_Gateway.php
@@ -385,7 +385,7 @@ class WC_Oxipay_Gateway extends WC_Payment_Gateway {
             $cart  = WC()->session->get('cart', null);
 
             $isJSON = ($_SERVER['REQUEST_METHOD'] === "POST" && isset($_SERVER['CONTENT_TYPE']) &&
-                       $_SERVER['CONTENT_TYPE'] === "application/json");
+                       (strpos($_SERVER['CONTENT_TYPE'], 'application/json') !== false) );
             $params;
             $msg;
 


### PR DESCRIPTION
Just check that the application/json is contained in the content type header rather than an explicit match.